### PR TITLE
Add base Dockerfile along with a couple shell scripts to build and run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:14-alpine
+
+ENV SPARK_HOME=/usr/lib/python3.7/site-packages/pyspark
+
+RUN apk add bash
+RUN apk add python3
+RUN pip3 install --upgrade pip
+RUN pip3 install pyspark
+
+RUN ln /usr/bin/python3.7 /usr/bin/python
+
+WORKDIR /src
+
+COPY . /src

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --tag bigdata .

--- a/run_image.sh
+++ b/run_image.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -i -t bigdata /bin/bash


### PR DESCRIPTION
Configuration for a docker image that contains:
- JDK
- Python 3
- Pyspark

A couple of tiny shell scripts are added to serve as reminder around how to build and run a shell. The intent is for interactive usage of `spark-submit` once the shell is loaded