### PR TITLE
Consolidate all Docker RUN commands to streamline image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM openjdk:14-alpine
 
 ENV SPARK_HOME=/usr/lib/python3.7/site-packages/pyspark
 
-RUN apk add bash
-RUN apk add python3
-RUN pip3 install --upgrade pip
-RUN pip3 install pyspark
-
-RUN ln /usr/bin/python3.7 /usr/bin/python
+RUN apk add bash && \
+  apk add python3 && \
+  pip3 install --upgrade pip && \
+  pip3 install pyspark && \
+  ln /usr/bin/python3.7 /usr/bin/python
 
 WORKDIR /src
 


### PR DESCRIPTION
Multiple `RUN` statements is not as efficient. Use a single `RUN` command and use `&&` between each internal shell command to trigger a single build-time layer but with multiple shell operations